### PR TITLE
Properly pass authorization scope

### DIFF
--- a/lib/omniauth/strategies/pandadoc.rb
+++ b/lib/omniauth/strategies/pandadoc.rb
@@ -5,7 +5,7 @@ module OmniAuth
   module Strategies
     # Main class for Pandadoc OAuth2 strategy.
     class Pandadoc < OmniAuth::Strategies::OAuth2
-      DEFAULT_SCOPE = 'read+write'
+      DEFAULT_SCOPE = 'read+write'.freeze
 
       option :client_options,
              site: 'https://api.pandadoc.com/public/v1',
@@ -14,8 +14,10 @@ module OmniAuth
 
       option :provider_ignores_state, true # this is needed for local testing
 
-      def request_phase
-        redirect client.auth_code.authorize_url({ redirect_uri: callback_url }.merge(options.authorize_params))
+      def authorize_params
+        super.tap do |params|
+          params[:scope] ||= DEFAULT_SCOPE
+        end
       end
     end
   end

--- a/spec/omniauth/strategies/pandadoc_spec.rb
+++ b/spec/omniauth/strategies/pandadoc_spec.rb
@@ -105,4 +105,18 @@ describe OmniAuth::Strategies::Pandadoc do
       expect(subject.callback_path).to eq('/auth/foo/callback')
     end
   end
+
+  describe '#authorize_params' do
+    it 'takes a custom scope' do
+      @options = { scope: 'foo' }
+
+      expect(subject.authorize_params[:scope]).to eq 'foo'
+    end
+
+    it 'provides a default scope if none is provided' do
+      @options = {}
+
+      expect(subject.authorize_params[:scope]).to eq described_class::DEFAULT_SCOPE
+    end
+  end
 end


### PR DESCRIPTION
We were improperly overriding the `request_phase` method, using
`options.authorize_params` rather than just `authorize_params`. When
fixed, we were rewriting the parent method word for word so it has been
removed from here.

Properly implement DEFAULT_SCOPE by extending the `authorized_params`
method.