### PR TITLE
Update for current Rubocop, and bump a couple of dependency versions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,14 +1,24 @@
-ClassLength:
+Gemspec/RequiredRubyVersion:
   Enabled: false
-Layout/IndentHeredoc:
+Layout/EmptyLinesAroundAttributeAccessor:
+  Enabled: true
+Layout/HeredocIndentation:
   Enabled: false
+Layout/LineLength:
+  Enabled: false
+Lint/RaiseException:
+  Enabled: true
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: true
+Lint/StructNewOverride:
+  Enabled: true
 Metrics/AbcSize:
   Enabled: false
 Metrics/BlockLength:
   ExcludedMethods: ['describe', 'context']
-Metrics/CyclomaticComplexity:
+Metrics/ClassLength:
   Enabled: false
-Metrics/LineLength:
+Metrics/CyclomaticComplexity:
   Enabled: false
 Metrics/MethodLength:
   Enabled: false
@@ -16,8 +26,16 @@ Metrics/PerceivedComplexity:
   Enabled: false
 Naming:
   Enabled: false
+Style/ExponentialNotation:
+  Enabled: true
+Style/HashEachMethods:
+  Enabled: true
+Style/HashTransformKeys:
+  Enabled: true
+Style/HashTransformValues:
+  Enabled: true
 Style/MutableConstant:
   Enabled: false
-Gemspec/RequiredRubyVersion:
-  Enabled: false
+Style/SlicingWithRange:
+  Enabled: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_install:
   - gem update --system
   - gem --version
 rvm:
+  - 2.7
+  - 2.6
   - 2.5
   - 2.4
-  - 2.3
-  - 2.2

--- a/lib/omniauth/pandadoc/version.rb
+++ b/lib/omniauth/pandadoc/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAuth
   module Pandadoc
-    VERSION = '1.0.0rc4'
+    VERSION = '1.0.0'
   end
 end

--- a/lib/omniauth/strategies/pandadoc.rb
+++ b/lib/omniauth/strategies/pandadoc.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'omniauth'
 require 'omniauth-oauth2'
 
@@ -5,7 +7,7 @@ module OmniAuth
   module Strategies
     # Main class for Pandadoc OAuth2 strategy.
     class Pandadoc < OmniAuth::Strategies::OAuth2
-      DEFAULT_SCOPE = 'read+write'.freeze
+      DEFAULT_SCOPE = 'read+write'
 
       option :client_options,
              site: 'https://api.pandadoc.com/public/v1',

--- a/omniauth-pandadoc.gemspec
+++ b/omniauth-pandadoc.gemspec
@@ -19,11 +19,11 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.2'
 
-  gem.add_runtime_dependency 'jwt', '~> 1.5'
+  gem.add_runtime_dependency 'jwt', '~> 2'
   gem.add_runtime_dependency 'omniauth', '~> 1.2'
   gem.add_runtime_dependency 'omniauth-oauth2', '~> 1.3'
 
   gem.add_development_dependency 'rake', '~> 12.0'
-  gem.add_development_dependency 'rspec', '~> 3.7'
+  gem.add_development_dependency 'rspec', '~> 3'
   gem.add_development_dependency 'rubocop', '~> 0.58'
 end


### PR DESCRIPTION
Mostly this is to get us updated to jwt 2.0+, which lets iss get set as an array, allowing us to update google-omniauth-oauth2 to the latest version, to fix the `JWT::InvalidIssuerError: Invalid issuer. Expected accounts.google.com, received https://accounts.google.com` issue.